### PR TITLE
Added missing semicolons to make the code  work with a simple minifier

### DIFF
--- a/fields/modules/assets/js/modules.js
+++ b/fields/modules/assets/js/modules.js
@@ -16,7 +16,7 @@
       filter: '*'
     };
 
-    this.options = $.extend({}, defaults, options)
+    this.options = $.extend({}, defaults, options);
 
     this.$tabs = $(el);
 
@@ -44,11 +44,11 @@
     } else {
       this.toggle(this.items().find('a').first());
     }
-  }
+  };
 
   Tabs.prototype.items = function(){
     return this.$tabs.find(this.options.filter);
-  }
+  };
 
   Tabs.prototype.activate = function($target){
     targetForLink($target).show();
@@ -62,7 +62,7 @@
 
     this.items().find('a').each(function(){
       targetForLink(this).hide();
-    })
+    });
 
     this.activate($target);
   };
@@ -147,13 +147,13 @@
     if(arr.length < 1) return null;
 
     return arr[arr.length - 1];
-  }
+  };
 
   var first = function(arr) {
     if(!arr.length) return null;
 
     return arr[0]
-  }
+  };
 
   var Modules = function(el) {
     var element  = $(el);


### PR DESCRIPTION
We are using the minifyhtml plugin, which removes all the whitespace from javascript files as a really simple method of minifying it, which means that it'll break the Javascript if there are any missing semicolons. It's a rather popular plugin and to make it directly work with the kirby-modules plugin, I simply added the missing semicolons.
